### PR TITLE
Renamed "_target" to "target" to make it work with merged-mine-proxy

### DIFF
--- a/qa/rpc-tests/getauxblock.py
+++ b/qa/rpc-tests/getauxblock.py
@@ -27,7 +27,7 @@ class GetAuxBlockTest (BitcoinTestFramework):
     assert_equal (auxblock['previousblockhash'], blocktemplate['previousblockhash'])
 
     # Compare target and take byte order into account.
-    target = auxblock['_target']
+    target = auxblock['target']
     reversedTarget = auxpow.reverseHex (target)
     assert_equal (reversedTarget, blocktemplate['target'])
 

--- a/qa/rpc-tests/test_framework/auxpow.py
+++ b/qa/rpc-tests/test_framework/auxpow.py
@@ -63,7 +63,7 @@ def mineAuxpowBlock (node):
   """
 
   auxblock = node.getauxblock ()
-  target = reverseHex (auxblock['_target'])
+  target = reverseHex (auxblock['target'])
   apow = computeAuxpow (auxblock['hash'], target, True)
   res = node.getauxblock (auxblock['hash'], apow)
   assert res

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -772,7 +772,7 @@ UniValue getauxblock(const UniValue& params, bool fHelp)
             "  \"coinbasevalue\"      (numeric) value of the block's coinbase\n"
             "  \"bits\"               (string) compressed target of the block\n"
             "  \"height\"             (numeric) height of the block\n"
-            "  \"_target\"            (string) target in reversed byte order, deprecated\n"
+            "  \"target\"            (string) target in reversed byte order, deprecated\n"
             "}\n"
             "\nResult (with arguments):\n"
             "xxxxx        (boolean) whether the submitted block was correct\n"
@@ -873,7 +873,7 @@ UniValue getauxblock(const UniValue& params, bool fHelp)
         result.push_back(Pair("coinbasevalue", (int64_t)block.vtx[0].vout[0].nValue));
         result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
         result.push_back(Pair("height", static_cast<int64_t> (pindexPrev->nHeight + 1)));
-        result.push_back(Pair("_target", HexStr(BEGIN(target), END(target))));
+        result.push_back(Pair("target", HexStr(BEGIN(target), END(target))));
 
         return result;
     }


### PR DESCRIPTION
Changing back "_target" to "target" to allow merged-mine-proxy to work as expected with namecore.
Tested and finding blocks with this fixed.