### PR TITLE
Clarify auxpow computations wrt system compatibility.

### DIFF
--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -170,16 +170,16 @@ CAuxPow::check (const uint256& hashAuxBlock, int nChainId,
     if (script.end() - pc < 8)
         return error("Aux POW missing chain merkle tree size and nonce in parent coinbase");
 
-    int nSize;
+    uint32_t nSize;
     memcpy(&nSize, &pc[0], 4);
+    nSize = le32toh (nSize);
     const unsigned merkleHeight = vChainMerkleBranch.size ();
-    if (nSize != (1 << merkleHeight))
+    if (nSize != (1u << merkleHeight))
         return error("Aux POW merkle branch size does not match parent coinbase");
 
     uint32_t nNonce;
     memcpy(&nNonce, &pc[4], 4);
     nNonce = le32toh (nNonce);
-
     if (nChainIndex != getExpectedIndex (nNonce, nChainId, merkleHeight))
         return error("Aux POW wrong index");
 

--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -7,6 +7,7 @@
 
 #include "auxpow.h"
 
+#include "compat/endian.h"
 #include "consensus/consensus.h"
 #include "consensus/validation.h"
 #include "main.h"
@@ -175,8 +176,9 @@ CAuxPow::check (const uint256& hashAuxBlock, int nChainId,
     if (nSize != (1 << merkleHeight))
         return error("Aux POW merkle branch size does not match parent coinbase");
 
-    int nNonce;
+    uint32_t nNonce;
     memcpy(&nNonce, &pc[4], 4);
+    nNonce = le32toh (nNonce);
 
     if (nChainIndex != getExpectedIndex (nNonce, nChainId, merkleHeight))
         return error("Aux POW wrong index");
@@ -185,7 +187,7 @@ CAuxPow::check (const uint256& hashAuxBlock, int nChainId,
 }
 
 int
-CAuxPow::getExpectedIndex (int nNonce, int nChainId, unsigned h)
+CAuxPow::getExpectedIndex (uint32_t nNonce, int nChainId, unsigned h)
 {
   // Choose a pseudo-random slot in the chain merkle tree
   // but have it be fixed for a size/nonce/chain combination.
@@ -194,7 +196,15 @@ CAuxPow::getExpectedIndex (int nNonce, int nChainId, unsigned h)
   // same chain while reducing the chance that two chains clash
   // for the same slot.
 
-  unsigned rand = nNonce;
+  /* This computation can overflow the uint32 used.  This is not an issue,
+     though, since we take the mod against a power-of-two in the end anyway.
+     This also ensures that the computation is, actually, consistent
+     even if done in 64 bits as it was in the past on some systems.
+
+     Note that h is always <= 30 (enforced by the maximum allowed chain
+     merkle branch length), so that 32 bits are enough for the computation.  */
+
+  uint32_t rand = nNonce;
   rand = rand * 1103515245 + 12345;
   rand += nChainId;
   rand = rand * 1103515245 + 12345;

--- a/src/auxpow.h
+++ b/src/auxpow.h
@@ -172,7 +172,7 @@ public:
    * @param h The merkle block height.
    * @return The expected index for the aux hash.
    */
-  static int getExpectedIndex (int nNonce, int nChainId, unsigned h);
+  static int getExpectedIndex (uint32_t nNonce, int nChainId, unsigned h);
 
 };
 


### PR DESCRIPTION
Explicitly use uint32_t for a computation in auxpow and add comment to make it clear that it is correct for all system architectures.  Also add an explicit endian-conversion.  See https://github.com/namecoin/namecore/issues/23.

Please review and test, but *do not merge*.  When I get an ACK, I will work this into the auxpow branch first and then merge from there to master.